### PR TITLE
Fix artifact and group IDs for Maven

### DIFF
--- a/docs/reference/layouts/shortcodes/install.html
+++ b/docs/reference/layouts/shortcodes/install.html
@@ -5,8 +5,8 @@
 <pre><code class="ini">
 &lt;dependencies&gt;
     &lt;dependency&gt;
-        &lt;groupId&gt;org.mongodb&lt;/groupId&gt;
-        &lt;artifactId&gt;{{$artifactId}}&lt;/artifactId&gt;
+        &lt;groupId&gt;org.mongodb.scala&lt;/groupId&gt;
+        &lt;artifactId&gt;{{$artifactId}}_{{$scalaVersion}}&lt;/artifactId&gt;
         &lt;version&gt;{{$version}}&lt;/version&gt;
     &lt;/dependency&gt;
 &lt;/dependencies&gt;


### PR DESCRIPTION
Group ID and Artifact ID for Maven example were missing ".scala" and _2.11 respectively