### PR TITLE
Update quickStart.html

### DIFF
--- a/docs/landing/layouts/partials/quickStart.html
+++ b/docs/landing/layouts/partials/quickStart.html
@@ -60,8 +60,8 @@
 <pre><code>
 &lt;dependencies&gt;
     &lt;dependency&gt;
-        &lt;groupId&gt;org.mongodb&lt;/groupId&gt;
-        &lt;artifactId&gt;{{$currentDriver}}&lt;/artifactId&gt;
+        &lt;groupId&gt;org.mongodb.scala&lt;/groupId&gt;
+        &lt;artifactId&gt;{{$currentDriver}}_2.11&lt;/artifactId&gt;
         &lt;version&gt;{{$currentVersion.version}}&lt;/version&gt;
     &lt;/dependency&gt;
 &lt;/dependencies&gt;
@@ -92,8 +92,8 @@ resolvers += "Snapshots" at "https://oss.sonatype.org/content/repositories/snaps
 <pre><code>
 &lt;dependencies&gt;
     &lt;dependency&gt;
-        &lt;groupId&gt;org.mongodb&lt;/groupId&gt;
-        &lt;artifactId&gt;{{$currentDriver}}&lt;/artifactId&gt;
+        &lt;groupId&gt;org.mongodb.scala&lt;/groupId&gt;
+        &lt;artifactId&gt;{{$currentDriver}}_2.11&lt;/artifactId&gt;
         &lt;version&gt;{{$currentVersion.version}}&lt;/version&gt;
     &lt;/dependency&gt;
 &lt;/dependencies&gt;


### PR DESCRIPTION
Fix maven dependency groupId, and artifactId.

Not sure if $.Site.Data.releases.driverName is somehow fixable, or docs on http://mongodb.github.io/mongo-scala-driver/1.1/getting-started/installation-guide/ are outdated though...

in the docs: 

<dependencies>
    <dependency>
        <groupId>org.mongodb</groupId>
        <artifactId>mongo-scala-driver</artifactId>
        <version>1.1.0</version>
    </dependency>
</dependencies>

in maven http://search.maven.org/#artifactdetails%7Corg.mongodb.scala%7Cmongo-scala-driver_2.11%7C1.1.0%7Cjar :

<dependency>
    <groupId>org.mongodb.scala</groupId>
    <artifactId>mongo-scala-driver_2.11</artifactId>
    <version>1.1.0</version>
</dependency> 