### PR TITLE
Change latest version number in Changelog to 2.2.1

### DIFF
--- a/docs/reference/content/changelog.md
+++ b/docs/reference/content/changelog.md
@@ -10,7 +10,7 @@ title = "Changelog"
 
 Changes between released versions
 
-### 2.2.2
+### 2.2.1
 
   * Updated MongoDB Driver Async to 3.6.3, fixes implicit session leak. [SCALA-378](https://jira.mongodb.org/browse/SCALA-378)
 


### PR DESCRIPTION
There is no 2.2.2 version currently. I imagine it was a typo.