### PR TITLE
Map .headOption on the executing thread

### DIFF
--- a/driver/src/main/scala/org/mongodb/scala/Helpers.scala
+++ b/driver/src/main/scala/org/mongodb/scala/Helpers.scala
@@ -16,6 +16,9 @@
 
 package org.mongodb.scala
 
+import java.util.concurrent.Executor
+
+import scala.concurrent.ExecutionContext
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
@@ -33,4 +36,7 @@ private[scala] object Helpers {
    */
   implicit def classTagToClassOf[C](ct: ClassTag[C]): Class[C] = ct.runtimeClass.asInstanceOf[Class[C]]
 
+  final val DirectExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(new Executor {
+    override def execute(command: Runnable): Unit = command.run()
+  })
 }

--- a/driver/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
+++ b/driver/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
@@ -18,10 +18,8 @@ package org.mongodb.scala
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.{Success, Try}
-
+import scala.util.Try
 import com.mongodb.async.client.{Observable => JObservable, Observer => JObserver, Subscription => JSubscription}
-
 import org.mongodb.scala.internal._
 
 /**
@@ -343,11 +341,10 @@ trait ObservableImplicits {
      * @return the head result of the [[Observable]].
      */
     def head(): Future[T] = {
-      import scala.concurrent.ExecutionContext.Implicits.global
       headOption().map {
         case Some(result) => result
         case None         => null.asInstanceOf[T] // scalastyle:ignore null
-      }
+      }(Helpers.DirectExecutionContext)
     }
 
     /**


### PR DESCRIPTION
Lately, I was suprised to find logs from the global Scala execution context when using `.headOption`. My proposal would be to use the executing/invoking thread, similarly to Guava's [`directExecutor()`](https://google.github.io/guava/releases/23.0/api/docs/com/google/common/util/concurrent/MoreExecutors.html#directExecutor--). This should be faster, less suprising and hopefully still correct, unless I missed the reason for scheduling the mapping on the default pool.