### PR TITLE
Support Set in case classes

### DIFF
--- a/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
+++ b/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
@@ -194,7 +194,11 @@ trait MacroCodec[T] extends Codec[T] {
       list.append(readValue(reader, decoderContext, typeArgs.head, typeArgs.tail, fieldTypeArgsMap))
     }
     reader.readEndArray()
-    list.toList.asInstanceOf[V]
+    if (clazz.isAssignableFrom(classOf[scala.collection.immutable.Set[_]])) {
+      list.toSet.asInstanceOf[V]
+    } else {
+      list.toList.asInstanceOf[V]
+    }
   }
 
   protected def readDocument[V](reader: BsonReader, decoderContext: DecoderContext, clazz: Class[V], typeArgs: List[Class[_]],

--- a/bson/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
+++ b/bson/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
@@ -78,6 +78,8 @@ class MacrosSpec extends FlatSpec with Matchers {
   case class OptionalCaseClass(name: String, value: Option[Person])
   case class OptionalRecursive(name: String, value: Option[OptionalRecursive])
 
+  case class SetValue(value: Set[String])
+
   sealed class Tree
   case class Branch(b1: Tree, b2: Tree, value: Int) extends Tree
   case class Leaf(value: Int) extends Tree
@@ -203,6 +205,10 @@ class MacrosSpec extends FlatSpec with Matchers {
       OptionalRecursive("Bob", Some(OptionalRecursive("Charlie", None))),
       """{name: "Bob", value: {name: "Charlie", value: null}}""", classOf[OptionalRecursive]
     )
+  }
+
+  it should "be able to round trip Set values" in {
+    roundTrip(SetValue(Set("value")), """{value: ["value"]}""", classOf[SetValue])
   }
 
   it should "be able to round trip Map values where the top level implementations don't include type information" in {


### PR DESCRIPTION
[Fixes SCALA-346](https://jira.mongodb.org/projects/SCALA/issues/SCALA-346?filter=allissues). The issue states:

> The reasoning for no initial support is there is no BSON type that equates to a Set, so decoding a BsonArray to a Set could lose fidelity of the data


I may have some counterarguments:

- BSON is used with MongoDB and MongoDB is very flexible and I think it's okay to give more precise semantics to `array` type in client-side schema. 
- command `$addToSet` exists, so I think it means that MongoDB allows to treat in some cases `array` as a `set` without directly enforcing it as a type. So Scala's type system may come to help here enforcing it in client-side schema.