### PR TITLE
Allow string type aliases as Map keys

### DIFF
--- a/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
+++ b/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
@@ -145,7 +145,8 @@ private[codecs] object CaseClassCodec {
     def flattenTypeArgs(at: Type): List[c.universe.Type] = {
       val t = at.dealias
       val typeArgs = t.typeArgs match {
-        case head :: _ if isMap(t) && head != stringType => c.abort(c.enclosingPosition, "Maps must contain string types for keys")
+        case head :: _ if isMap(t) && !(head =:= stringType) =>
+          c.abort(c.enclosingPosition, "Maps must contain string types for keys")
         case _ :: tail if isMap(t) /* head == stringType */ => tail
         case args => args
       }

--- a/bson/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
+++ b/bson/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
@@ -63,6 +63,9 @@ class MacrosSpec extends FlatSpec with Matchers {
   case class SeqOfMapOfStrings(name: String, value: Seq[Map[String, String]])
   case class RecursiveMapOfStrings(name: String, value: Seq[Map[String, RecursiveMapOfStrings]])
 
+  type StringAlias = String
+  case class MapOfStringAliases(name: String, value: Map[StringAlias, StringAlias])
+
   case class ContainsCaseClass(name: String, friend: Person)
   case class ContainsSeqCaseClass(name: String, friends: Seq[Person])
   case class ContainsNestedSeqCaseClass(name: String, friends: Seq[Seq[Person]])
@@ -165,6 +168,7 @@ class MacrosSpec extends FlatSpec with Matchers {
     roundTrip(RecursiveSeq("Bob", Seq(RecursiveSeq("Charlie", Seq.empty[RecursiveSeq]))), """{name: "Bob", value: [{name: "Charlie", value: []}]}""", classOf[RecursiveSeq])
     roundTrip(AnnotatedClass("Bob"), """{annotated_name: "Bob"}""", classOf[AnnotatedClass])
     roundTrip(MapOfStrings("Bob", Map("brother" -> "Tom Jones")), """{name: "Bob", value: {brother: "Tom Jones"}}""", classOf[MapOfStrings])
+    roundTrip(MapOfStringAliases("Bob", Map("brother" -> "Tom Jones")), """{name: "Bob", value: {brother: "Tom Jones"}}""", classOf[MapOfStringAliases])
     roundTrip(SeqOfMapOfStrings("Bob", Seq(Map("brother" -> "Tom Jones"))), """{name: "Bob", value: [{brother: "Tom Jones"}]}""", classOf[SeqOfMapOfStrings])
   }
 


### PR DESCRIPTION
`CaseClassCodec` didn't allow any other type than `String` for Map keys, even if it's only a type alias.

This change replaces the `==` comparison with `=:=` which resolves aliases and is recommended for type equality checks.

Use case:
```
type Language = String
case class Thing(translations: Map[Language, String])
```