### PR TITLE
Fix `UninitializedFieldError` in MacroCodecs under `-Xcheckinit`

### DIFF
--- a/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
+++ b/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
@@ -307,11 +307,12 @@ private[codecs] object CaseClassCodec {
         import org.bson.codecs.configuration.CodecRegistry
         import org.mongodb.scala.bson.codecs.macrocodecs.MacroCodec
 
-        case class $codecName(codecRegistry: CodecRegistry) extends MacroCodec[$classTypeName] {
+        final case class $codecName(codecRegistry: CodecRegistry) extends {
+          val encoderClass = classOf[$classTypeName]
+        } with MacroCodec[$classTypeName] {
           val caseClassesMap = $caseClassesMap
           val classToCaseClassMap = $classToCaseClassMap
           val classFieldTypeArgsMap = $createClassFieldTypeArgsMap
-          val encoderClass = classOf[$classTypeName]
           def getInstance(className: String, fieldData: Map[String, Any]) = $getInstance
           def writeCaseClassData(className: String, writer: BsonWriter, value: $mainType, encoderContext: EncoderContext) = $writeValue
         }

--- a/project/MongoScalaBuild.scala
+++ b/project/MongoScalaBuild.scala
@@ -47,7 +47,7 @@ object MongoScalaBuild extends Build {
     scalacOptions in IntegrationTest := scalacOptionsTest
   )
 
-  val scalacOptionsTest: Seq[String] = Seq( "-unchecked", "-deprecation", "-feature", "-Xlint:-missing-interpolator,_")
+  val scalacOptionsTest: Seq[String] = Seq( "-unchecked", "-deprecation", "-feature", "-Xlint:-missing-interpolator,_", "-Xcheckinit")
 
   def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
     Seq( "-unchecked", "-deprecation", "-feature", "-Ywarn-dead-code"


### PR DESCRIPTION
~_Note:_ This is a reproducer for the error, which could also serve as a basis of fixing it.~

In our project we usually use the scalac options from [here](https://tpolecat.github.io/2017/04/25/scalac-flags.html), including `-Xcheckinit` which causes the compiler to emit additional code that checks whether members of a class are already initialized before they are accessed.

This is not the case for the generated CodecProviders.

```
[error] (run-main-d) scala.UninitializedFieldError: Uninitialized field: /home/claudio/src/project/app/example/data/models/stencils/Foo.scala: 7
[error] scala.UninitializedFieldError: Uninitialized field: /home/claudio/src/project/app/example/data/models/stencils/Foo.scala: 7
[error] 	at eve.data.models.properties.PropertyCodec$$anon$1$PropertyMacroCodec$1.encoderClass(Foo.scala:7)
[error] 	at org.mongodb.scala.bson.codecs.macrocodecs.MacroCodec.getEncoderClass(MacroCodec.scala:113)
[error] 	at org.mongodb.scala.bson.codecs.macrocodecs.MacroCodec.getEncoderClass$(MacroCodec.scala:113)
[error] 	at eve.data.models.properties.PropertyCodec$$anon$1$PropertyMacroCodec$1.getEncoderClass(Foo.scala:7)
[error] 	at org.bson.codecs.configuration.MapOfCodecsProvider.<init>(MapOfCodecsProvider.java:30)
[error] 	at org.bson.codecs.configuration.CodecRegistries.fromCodecs(CodecRegistries.java:56)
[error] 	at org.bson.codecs.configuration.CodecRegistries.fromCodecs(CodecRegistries.java:43)
[error] 	at org.mongodb.scala.bson.codecs.macrocodecs.MacroCodec.$init$(MacroCodec.scala:85)
[error] 	at eve.data.models.properties.PropertyCodec$$anon$1$PropertyMacroCodec$1.<init>(Foo.scala:7)
[error] 	at eve.data.models.properties.PropertyCodec$$anon$1$PropertyMacroCodec$2$.apply(Foo.scala:7)
[error] 	at eve.data.models.properties.PropertyCodec$$anon$1.get(Foo.scala:7)
[error] 	at eve.data.Run$.main(Run.scala:51)
[error] 	at eve.data.Run.main(Run.scala)
```

The reason is because `this` is given to the `MapOfCodecsProvider` constructor [here](https://github.com/mongodb/mongo-scala-driver/blob/3e531e10f67eef3b633ea932aaa241d14fced6b3/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala#L85) which calls `getCodecClass` while the class is not yet initialized.