### PR TITLE
Deprecated useless apply method

### DIFF
--- a/bson/src/main/scala/org/mongodb/scala/bson/BsonValue.scala
+++ b/bson/src/main/scala/org/mongodb/scala/bson/BsonValue.scala
@@ -43,7 +43,16 @@ object BsonArray {
    * @param elems the `BsonValues` to become the `BsonArray`
    * @return the BsonArray
    */
+  @deprecated("Use fromIterable instead", "2.6.1")
   def apply(elems: Iterable[BsonValue]): BsonArray = new BsonArray(elems.toList.asJava)
+  
+  /**
+   * Create a BsonArray from the provided values
+   *
+   * @param elems the `BsonValues` to become the `BsonArray`
+   * @return the BsonArray
+   */
+  def fromIterable(elems: Iterable[BsonValue]): BsonArray = new BsonArray(elems.toList.asJava)
 
   /**
    * Creates a BsonArray from the provided values


### PR DESCRIPTION
Copy and pasted from this ticket: https://jira.mongodb.org/browse/SCALA-531

BsonArray.apply has two overloads to the `def apply(elems: CanBeBsonValue*): BsonArray` signature. 
The first one takes no parameters and is useless since it's the same as passing no args to the vararg signature.
The second one takes an `Iterable[BsonValue]` and this one tripped me up bad, because I wanted to call this one, but after some long debugging session found out I wasn't calling it at all. Instead, since any `Seq` will automatically be converted to a `BsonArray`, calling something like `BsonArray(List("Hello", "World"))` will result in `[["Hello", "World"]]`. The only way to call this method is to call it with something that is an `Iterable` but not a `Seq`, which is at the very least hard to come by. I suggest deleting the two overloads and adding a `fromIterable` function.