### PR TITLE
Write the type of sealed traits with only one subclass

### DIFF
--- a/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
+++ b/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
@@ -80,7 +80,7 @@ trait MacroCodec[T] extends Codec[T] {
    * The field used to save the class name when saving sealed case classes.
    */
   val classFieldName = "_t"
-  lazy val hasClassFieldName: Boolean = caseClassesMap.size > 1
+  lazy val hasClassFieldName: Boolean = caseClassesMapInv.keySet != Set(encoderClass)
   lazy val caseClassesMapInv: Map[Class[_], String] = caseClassesMap.map(_.swap)
   protected val registry: CodecRegistry = CodecRegistries.fromRegistries(List(codecRegistry, CodecRegistries.fromCodecs(this)).asJava)
   protected val bsonNull = BsonNull()

--- a/bson/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
+++ b/bson/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
@@ -151,6 +151,15 @@ class MacrosSpec extends FlatSpec with Matchers {
   case class SealedTraitB(intField: Int) extends SealedTrait
   case class ContainsSealedTrait(list: List[SealedTrait])
 
+  sealed class SingleSealedClass
+  case class SingleSealedClassImpl() extends SingleSealedClass
+
+  sealed abstract class SingleSealedAbstractClass
+  case class SingleSealedAbstractClassImpl() extends SingleSealedAbstractClass
+
+  sealed trait SingleSealedTrait
+  case class SingleSealedTraitImpl() extends SingleSealedTrait
+
   object CaseObjectEnumCodecProvider extends CodecProvider {
     def isCaseObjectEnum[T](clazz: Class[T]): Boolean = {
       clazz.isInstance(CaseObjectEnum.Alpha) || clazz.isInstance(CaseObjectEnum.Bravo) || clazz.isInstance(CaseObjectEnum.Charlie)
@@ -371,6 +380,12 @@ class MacrosSpec extends FlatSpec with Matchers {
     roundTrip(ContainsSeqADT("Bob", List(leaf, branch)), s"""{name: "Bob", trees: [$leafJson, $branchJson]}""", classOf[ContainsSeqADT], classOf[Tree])
     roundTrip(ContainsNestedSeqADT("Bob", List(List(leaf), List(branch))), s"""{name: "Bob", trees: [[$leafJson], [$branchJson]]}""",
       classOf[ContainsNestedSeqADT], classOf[Tree])
+  }
+
+  it should "write the type of sealed classes and traits with only one subclass" in {
+    roundTrip(SingleSealedClassImpl(), """{ "_t" : "SingleSealedClassImpl" }""".stripMargin, classOf[SingleSealedClass])
+    roundTrip(SingleSealedAbstractClassImpl(), """{ "_t" : "SingleSealedAbstractClassImpl" }""".stripMargin, classOf[SingleSealedAbstractClass])
+    roundTrip(SingleSealedTraitImpl(), """{ "_t" : "SingleSealedTraitImpl" }""".stripMargin, classOf[SingleSealedTrait])
   }
 
   it should "support optional values in ADT sealed classes" in {


### PR DESCRIPTION
If classes have sublasses and a codec is created for the parent class, then a `_t` field should be added to the serialized json object. This does not work for a `sealed abstract class` or a `sealed trait` if it has only one implementing case class.

The following example compiles as expected ([see](https://github.com/mongodb/mongo-scala-driver/blob/45be366c427efbf81da42317c386e224ac70dab3/bson/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala#L376-L385)):
```scala
sealed class Graph
case class Node(name: String, value: Option[Graph]) extends Graph

Node("foo", None)
// .. serializes to ...
{"_t": "Node", "name": "nodeA", "value": null}
```

But following cases that are supported by the driver since #49 compile wrong:
```scala
sealed abstract class Graph
case class Node(name: String, value: Option[Graph]) extends Graph

Node("foo", None)
// .. serializes to ...
{"name": "nodeA", "value": null}
```
```scala
sealed trait Graph
case class Node(name: String, value: Option[Graph]) extends Graph

Node("foo", None)
// .. serializes to ...
{"name": "nodeA", "value": null}
```