### PR TITLE
Add Codec import in macro generated code

### DIFF
--- a/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
+++ b/bson/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
@@ -311,7 +311,7 @@ private[codecs] object CaseClassCodec {
       q"""
         import scala.collection.mutable
         import org.bson.{ BsonInvalidOperationException, BsonWriter }
-        import org.bson.codecs.EncoderContext
+        import org.bson.codecs.{ EncoderContext, Codec }
         import org.bson.codecs.configuration.CodecRegistry
         import org.mongodb.scala.bson.codecs.macrocodecs.MacroCodec
 


### PR DESCRIPTION
The code of codecs generated by the `Macros` references the `Codec` class, but does not import the class. This causes a "No such class `Codec`" compiler error unless the user explicitly imports the correct class himself.