### PR TITLE
Added method to handling $in for a scala Iterable.

### DIFF
--- a/driver/src/main/scala/org/mongodb/scala/model/Filters.scala
+++ b/driver/src/main/scala/org/mongodb/scala/model/Filters.scala
@@ -163,6 +163,17 @@ object Filters {
   def in[TItem](fieldName: String, values: TItem*): Bson = JFilters.in(fieldName, values.asJava)
 
   /**
+   * Creates a filter that matches all documents where the value of a field equals any value in the list of specified values.
+   *
+   * @param fieldName the field name
+   * @param values    the list of values
+   * @tparam TItem   the value type
+   * @return the filter
+   * @see [[http://docs.mongodb.org/manual/reference/operator/query/in \$in]]
+   */
+  def in[TItem](fieldName: String, values: Iterable[TItem]): Bson = JFilters.in(fieldName, values.asJava)
+
+  /**
    * Creates a filter that matches all documents where the value of a field does not equal any of the specified values or does not exist.
    *
    * @param fieldName the field name

--- a/driver/src/test/scala/org/mongodb/scala/model/FiltersSpec.scala
+++ b/driver/src/test/scala/org/mongodb/scala/model/FiltersSpec.scala
@@ -135,6 +135,7 @@ class FiltersSpec extends FlatSpec with Matchers {
 
   it should "render $in" in {
     toBson(model.Filters.in("a", 1, 2, 3)) should equal(Document("""{a : {$in : [1, 2, 3]} }"""))
+    toBson(model.Filters.in("a", Seq(1, 2, 3))) should equal(Document("""{a : {$in : [1, 2, 3]} }"""))
   }
 
   it should "render $nin" in {


### PR DESCRIPTION
When calling `Filters.in("a", Seq(1, 2, 3))` the resulting bson is `{a : {$in : [[1, 2, 3]]} }`, and not `{a : {$in : [1, 2, 3]} }` as expected.

Hope this fix can be merged, or fixed some other way.